### PR TITLE
Fixed distortion caused by incorrect volume formula

### DIFF
--- a/imfcreator/filetypes/imfmusicfile.py
+++ b/imfcreator/filetypes/imfmusicfile.py
@@ -70,7 +70,12 @@ class ImfMusicFile(object):
         # TODO include_tags, remarks, etc
         data = ""
         if file_type == 1:
-            data += struct.pack("<H", self.num_commands * 4)
+            length = self.num_commands * 4
+            if length > 65532:
+                print "WARNING: IMF file max buffer overflow (total commands given=%d; written commands=%d)" % (self.num_commands, (65532 / 4))
+                data += struct.pack("<H", 65532)
+            else:
+                data += struct.pack("<H", length)
         for command in self.commands:
             data += struct.pack("<BBH", *command)
         with open(filename, "wb") as f:

--- a/midi2imf.py
+++ b/midi2imf.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+import sys
+
+from imfcreator.filetypes import instrumentfile
+from imfcreator.imf_builder import convert_midi_to_imf
+from imfcreator.filetypes.midifileplugin import MidiReader
+
+instruments = instrumentfile.get_all_instruments("GENMIDI.OP2")  # .freedoom
+
+if not os.path.isfile("GENMIDI.OP2"):
+    shutil.copy("genmidi/GENMIDI.OP2", "GENMIDI.OP2")
+
+reader = MidiReader()
+if len(sys.argv) > 1:
+    reader.load(sys.argv[1])
+    imf = convert_midi_to_imf(reader, instruments, output_file_name=("%s.imf" % sys.argv[1]), imf_file_type=1)
+else:
+    print "Usage: %s <path to MIDI file>\n" % sys.argv[0]


### PR DESCRIPTION
Because of incorrect volume formula, generated IMF files aren't sounded good. I have fixed that:
- When voice is FM, scale carrier only
- When voice is AM, scale both operators
- KSL didn't aligned right, I have added the shift that fixes it