### PR TITLE
Make the controller value out of range to not fail

### DIFF
--- a/imfcreator/plugins/_midiengine.py
+++ b/imfcreator/plugins/_midiengine.py
@@ -252,7 +252,9 @@ class MidiChannelInfo:
         return self._controllers[controller]
 
     def set_controller_value(self, controller: _midi.ControllerType, value: int):
-        assert 0 <= value <= 127
+        if value > 127:
+            _logging.warning(f"Controller {controller} out of range (Given value {value})")
+            value &= 0x7f
         self._controllers[controller] = value
         # Check controller handlers.
         if controller in _CONTROLLER_HANDLERS:


### PR DESCRIPTION
This should fix the inability to open some MIDI files like this one: [Witchy_3.mid.zip](https://github.com/adambiser/imf-creator/files/6083831/Witchy_3.mid.zip)
